### PR TITLE
Add sbt.librarymanagement.Resolver

### DIFF
--- a/src/main/scala-sbt-0.13/compat.scala
+++ b/src/main/scala-sbt-0.13/compat.scala
@@ -39,6 +39,7 @@ package librarymanagement {
     type GetClassifiersModule = sbt.GetClassifiersModule
 
     type MavenRepository = sbt.MavenRepository
+    type Resolver = sbt.Resolver
 
     implicit class ModuleIDOps(val _m: ModuleID) extends AnyVal {
       def withConfigurations(configurations: Option[String]): ModuleID =


### PR DESCRIPTION
It seems that in order to resolve my dependency problem, I need to have sbt.librarymanagement.Resolver also available in 0.13.

See https://github.com/coursier/coursier/pull/746